### PR TITLE
Disable concurrent builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,6 +21,9 @@ pipeline {
   agent {
     label 'kubegit'
   }
+  options {
+    disableConcurrentBuilds()
+  }
   stages {
     stage('Update Deployment and Service specification') {
       steps {


### PR DESCRIPTION
Allowing concurrent builds causes the `k8s-deploy-staging` job to fail as the repo is often being updated with the latest release for one microservice while the repo is simultaneously trying to be updated for another microservice.

For example:
```+ cd k8s-deploy-staging/
+ git push https://****:****@github.com/acl-testing/k8s-deploy-staging
To https://github.com/acl-testing/k8s-deploy-staging
 ! [rejected]        master -> master (fetch first)
error: failed to push some refs to 'https://****:****@github.com/acl-testing/k8s-deploy-staging'
hint: Updates were rejected because the remote contains work that you do
hint: not have locally. This is usually caused by another repository pushing
hint: to the same ref. You may want to first integrate the remote changes
hint: (e.g., 'git pull ...') before pushing again.
hint: See the 'Note about fast-forwards' in 'git push --help' for details.```